### PR TITLE
docs: update script usage for interactive trades

### DIFF
--- a/Experiment Details/Using Scripts.md
+++ b/Experiment Details/Using Scripts.md
@@ -10,74 +10,50 @@ To run, just make sure there's data in `'chatgpt_portfolio_update.csv'`, then ru
 
 ## Trading_Script.py
 
-A little more complicated, the order of function calls are very important (listed at the bottom). There are 4 main functions:
+The trading script tracks positions, logs trades, and prints daily results.
 
 ### 1. Daily Results
 
-Gets trading data for the day (as long as the trading day has closed).  
+Gets trading data for the day (as long as the trading day has closed).
 If it's not a trading day, it will use data from the previous day.
 It will also print the updated portfolio and cash. **If any manual trades were made, be sure to copy both and update the code.**
-It will print data for all tickers in the `chatgpt_portfolio` Python dictionary.  
+By default the function also reports the Russell 2000 (`^RUT`), IWO, and XBI for comparison.
+
 To add additional tickers without modifying the portfolio:
 
 Before:
 
 ```python
 # say we want data from SPY
-for stock in chatgpt_portfolio + [{"ticker": "^RUT"}]:
+for stock in chatgpt_portfolio + [{"ticker": "^RUT"}] + [{"ticker": "IWO"}] + [{"ticker": "XBI"}]:
     print(stock)
 ```
 
 After:
 
 ```python
-for stock in chatgpt_portfolio + [{"ticker": "^RUT"}] + [{"ticker": "SPY"}]:
+for stock in chatgpt_portfolio + [{"ticker": "^RUT"}] + [{"ticker": "IWO"}] + [{"ticker": "XBI"}] + [{"ticker": "SPY"}]:
     print(stock)
 ```
 That's it!
+
 ### Process Portfolio
-Way simplier, automatically handles stoplosses and updating the `'chatgpt_portfolio_update.csv'`
+Handles stop-losses, updates `'chatgpt_portfolio_update.csv'`, and now prompts for manual trades before processing.
 
-### Manual Buy/Sell
+When prompted you can enter:
 
-Both require parameters. Here is manual_buy:
+- `b` to log a manual buy (ticker, shares, buy price, and stop loss)
+- `s` to log a manual sell (ticker, shares, and sell price)
+- press **Enter** to skip
+
+Any manual trades are saved to `chatgpt_trade_log.csv`.
+
+### Putting It Together
+At the bottom of your script, call:
+
 ```python
-log_manual_buy(buy_price, shares, ticker, cash, stoploss, chatgpt_portfolio)
-```
-
-Say I wanted to buy "F" (Ford), with a limit order of 12.00, share count of 10, and a stoploss of 9.00.
-
-That would look like:
-```python
-log_manual_buy(12.00, 10, "F", cash, 9.00, chatgpt_portfolio)
-```
-Cash and chatgpt_portfolio are already vars, so leave as is.
-
-Now, for manual_sell:
-```python
-log_manual_sell(sell_price, shares_sold, ticker, cash, chatgpt_portfolio)
-```
-
-If I wanted to sell 3 shares of PFE (Pfizer), with a limit order of 23.00:
-
-That would look like:
-```python
-log_manual_sell(23.00, 3, "PFE", cash, chatgpt_portfolio)
-```
-
-**NOTE: BOTH ORDERS WILL EXECUTE THE ORDER NO MATTER WHAT. BE SURE TO CHECK VALIDITY.**
-
-## Function Call Order
-1. Manual buying and selling
-2. Process Portfolio
-3. Daily Results
-
-How would all this look?
-At the very bottom, put:
-```python
-log_manual_sell(23.00, 3, "PFE", cash, chatgpt_portfolio)
-log_manual_buy(12.00, 10, "F", cash, 9.00, chatgpt_portfolio)
 chatgpt_portfolio = process_portfolio(chatgpt_portfolio, cash)
 daily_results(chatgpt_portfolio, cash)
 ```
-Of course, if no manual buys or sells were made, don't add those function calls.
+
+`process_portfolio` will ask about manual trades and update the CSV files automatically before `daily_results` prints the day's metrics.


### PR DESCRIPTION
## Summary
- document the new manual trade prompts in `process_portfolio`
- note default index tickers (^RUT, IWO, XBI) and how to extend `daily_results`
- simplify usage example to just `process_portfolio` and `daily_results`

## Testing
- `python -m py_compile 'Scripts and CSV Files/Generate_Graph.py' 'Scripts and CSV Files/Trading_Script.py'`


------
https://chatgpt.com/codex/tasks/task_e_688cf33c91748324868a05aa685878ce