### PR TITLE
Document usage of trading and graph scripts

### DIFF
--- a/Start Your Own/README.md
+++ b/Start Your Own/README.md
@@ -1,0 +1,44 @@
+# Start Your Own
+
+This folder lets you run the trading experiment on your own computer. It contains two small scripts and the CSV files they produce.
+
+Run the commands below from the repository root. The scripts automatically
+save their CSV data inside this folder.
+
+## Trading_Script.py
+
+This script updates your portfolio and logs trades.
+
+1. **Install Python packages**
+   ```bash
+   pip install pandas yfinance numpy matplotlib
+   ```
+2. **Set up your portfolio**
+   - Open `Trading_Script.py`.
+   - At the bottom of the file, change `starting_capital` and the `chatgpt_portfolio` list to match your tickers, share counts, stop losses, and buy prices.
+3. **Run the script**
+   ```bash
+   python "Start Your Own/Trading_Script.py"
+   ```
+4. **Follow the prompts**
+   - The script asks if you want to record manual buys or sells before it fetches prices.
+   - Daily results are saved to `chatgpt_portfolio_update.csv` and any trades are added to `chatgpt_trade_log.csv`.
+
+## Generate_Graph.py
+
+This script draws a graph of your portfolio versus the S&P 500.
+
+1. **Ensure you have portfolio data**
+   - Run `Trading_Script.py` at least once so `chatgpt_portfolio_update.csv` has data.
+2. **Run the graph script**
+   ```bash
+   python "Start Your Own/Generate_Graph.py" --baseline-equity 100
+   ```
+   - Optional flags `--start-date` and `--end-date` accept dates in `YYYY-MM-DD` format. For example:
+   ```bash
+   python "Start Your Own/Generate_Graph.py" --baseline-equity 100 --start-date 2023-01-01 --end-date 2023-12-31
+   ```
+3. **View the chart**
+   - A window opens showing your portfolio value and a $100 investment in the S&P 500.
+
+Both scripts are designed for beginners—feel free to experiment and modify them as you learn.

--- a/Start Your Own/Trading_Script.py
+++ b/Start Your Own/Trading_Script.py
@@ -6,7 +6,7 @@ logic or behaviour.
 """
 
 from datetime import datetime
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -14,9 +14,9 @@ import yfinance as yf
 from typing import cast
 
 # Shared file locations
-DATA_DIR = "Start Your Own"
-PORTFOLIO_CSV = f"{DATA_DIR}/chatgpt_portfolio_update.csv"
-TRADE_LOG_CSV = f"{DATA_DIR}/chatgpt_trade_log.csv"
+DATA_DIR = Path(__file__).resolve().parent
+PORTFOLIO_CSV = DATA_DIR / "chatgpt_portfolio_update.csv"
+TRADE_LOG_CSV = DATA_DIR / "chatgpt_trade_log.csv"
 
 # Today's date reused across logs
 today = datetime.today().strftime("%Y-%m-%d")
@@ -139,7 +139,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
     results.append(total_row)
 
     df = pd.DataFrame(results)
-    if os.path.exists(PORTFOLIO_CSV):
+    if PORTFOLIO_CSV.exists():
         existing = pd.read_csv(PORTFOLIO_CSV)
         existing = existing[existing["Date"] != today]
         print("rows for today already logged, not saving results to CSV...")
@@ -170,7 +170,7 @@ def log_sell(
 
     portfolio = portfolio[portfolio["ticker"] != ticker]
 
-    if os.path.exists(TRADE_LOG_CSV):
+    if TRADE_LOG_CSV.exists():
         df = pd.read_csv(TRADE_LOG_CSV)
         df = pd.concat([df, pd.DataFrame([log])], ignore_index=True)
     else:
@@ -215,7 +215,7 @@ def log_manual_buy(
         "Reason": "MANUAL BUY - New position",
     }
 
-    if os.path.exists(TRADE_LOG_CSV):
+    if TRADE_LOG_CSV.exists():
         df = pd.read_csv(TRADE_LOG_CSV)
         df = pd.concat([df, pd.DataFrame([log])], ignore_index=True)
     else:
@@ -279,7 +279,7 @@ def log_manual_sell(
         "Shares Sold": shares_sold,
         "Sell Price": sell_price,
     }
-    if os.path.exists(TRADE_LOG_CSV):
+    if TRADE_LOG_CSV.exists():
         df = pd.read_csv(TRADE_LOG_CSV)
         df = pd.concat([df, pd.DataFrame([log])], ignore_index=True)
     else:


### PR DESCRIPTION
## Summary
- resolve data-file paths relative to each script so `Trading_Script.py` and `Generate_Graph.py` can run from any directory
- clarify README instructions with root-level command examples and optional start/end date flags

## Testing
- `pip install numpy pandas yfinance matplotlib` *(fails: Could not connect to proxy)*
- `pytest`
- `pytest Start Your Own/Trading_Script.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest Start Your Own/Generate_Graph.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `python -m py_compile Start Your Own/Generate_Graph.py Start Your Own/Trading_Script.py`


------
https://chatgpt.com/codex/tasks/task_e_688d0209a0a88324a7542848908a3dd9