### PR TITLE
Clarify portfolio overwrite behavior

### DIFF
--- a/Scripts and CSV Files/Trading_Script.py
+++ b/Scripts and CSV Files/Trading_Script.py
@@ -151,8 +151,11 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> tuple[pd
     df = pd.DataFrame(results)
     if os.path.exists(PORTFOLIO_CSV):
         existing = pd.read_csv(PORTFOLIO_CSV)
-        existing = existing[existing["Date"] != today]
-        print("rows for today already logged, not saving results to CSV...")
+        if today in existing["Date"].values:
+            print(
+                "Rows for today already logged. Replacing existing entries before saving."
+            )
+            existing = existing[existing["Date"] != today]
         df = pd.concat([existing, df], ignore_index=True)
 
     df.to_csv(PORTFOLIO_CSV, index=False)

--- a/Start Your Own/Trading_Script.py
+++ b/Start Your Own/Trading_Script.py
@@ -153,8 +153,11 @@ Would you like to log a manual trade? Enter 'b' for buy, 's' for sell, or press 
     df = pd.DataFrame(results)
     if PORTFOLIO_CSV.exists():
         existing = pd.read_csv(PORTFOLIO_CSV)
-        existing = existing[existing["Date"] != today]
-        print("rows for today already logged, not saving results to CSV...")
+        if today in existing["Date"].values:
+            print(
+                "Rows for today already logged. Replacing existing entries before saving."
+            )
+            existing = existing[existing["Date"] != today]
         df = pd.concat([existing, df], ignore_index=True)
 
     df.to_csv(PORTFOLIO_CSV, index=False)


### PR DESCRIPTION
## Summary
- Clarify portfolio saving logic by notifying that existing rows for the current date are replaced before saving
- Apply same logic to Start Your Own script to keep behavior consistent across project

## Testing
- `python -m py_compile "Scripts and CSV Files/Trading_Script.py" "Start Your Own/Trading_Script.py"`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e7c1ba8a48324a0ece52a49fa39fd