### PR TITLE
fix: accept list input for portfolio

### DIFF
--- a/trading_script.py
+++ b/trading_script.py
@@ -415,15 +415,21 @@ def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
     )
 
 
-def main(chatgpt_portfolio: dict, cash: float, data_dir: Path | None = None) -> None:
+def main(
+    chatgpt_portfolio: pd.DataFrame | dict | list,
+    cash: float,
+    data_dir: Path | None = None,
+) -> None:
     """Run the trading script using ``data_dir`` for CSV storage."""
 
     if data_dir is not None:
         set_data_dir(data_dir)
 
-    if not isinstance(chatgpt_portfolio, (pd.DataFrame, dict)):
-        raise KeyError("The format for portfolio wasn't a dict or DataFrame.")
-    if isinstance(chatgpt_portfolio, dict):
+    if not isinstance(chatgpt_portfolio, (pd.DataFrame, dict, list)):
+        raise KeyError(
+            "The format for portfolio wasn't a dict, list of dicts, or DataFrame."
+        )
+    if not isinstance(chatgpt_portfolio, pd.DataFrame):
         chatgpt_portfolio = pd.DataFrame(chatgpt_portfolio)
 
     chatgpt_portfolio, cash = process_portfolio(chatgpt_portfolio, cash)


### PR DESCRIPTION
## Summary
- Allow `main` to accept a list of dictionaries or dict for the portfolio and convert to DataFrame as needed

## Testing
- `python -m py_compile trading_script.py`
- ⚠️ `pip install numpy pandas yfinance` *(failed: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_688e8138b2648324839e5e3b6124b847