### PR TITLE
Trigger stop-loss using daily low price

### DIFF
--- a/trading_script.py
+++ b/trading_script.py
@@ -142,15 +142,20 @@ Would you like to log a manual trade? Enter 'b' for buy, 's' for sell, or press 
                 "Total Equity": "",
             }
         else:
-            price = round(data["Close"].iloc[-1], 2)
-            value = round(price * shares, 2)
-            pnl = round((price - cost) * shares, 2)
+            low_price = round(float(data["Low"].iloc[-1]), 2)
+            close_price = round(float(data["Close"].iloc[-1]), 2)
 
-            if price <= stop:
+            if low_price <= stop:
+                price = stop
+                value = round(price * shares, 2)
+                pnl = round((price - cost) * shares, 2)
                 action = "SELL - Stop Loss Triggered"
                 cash += value
                 portfolio_df = log_sell(ticker, shares, price, cost, pnl, portfolio_df)
             else:
+                price = close_price
+                value = round(price * shares, 2)
+                pnl = round((price - cost) * shares, 2)
                 action = "HOLD"
                 total_value += value
                 total_pnl += pnl


### PR DESCRIPTION
## Summary
- Ensure stop-loss logic checks each day's low rather than only the close.
- When the low crosses a position's stop price, treat it as a sell at the stop price and log the trade.

## Testing
- `pytest`
- `python -m py_compile trading_script.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd5c9c52c8324a4a370beb80843db