### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application
+COPY . .
+
+# Default command runs the trading script
+CMD ["python", "trading_script.py"]

--- a/README.md
+++ b/README.md
@@ -77,5 +77,19 @@ Updates are posted weekly on my blog — more coming soon!
 
 One final shameless plug: (https://substack.com/@nathanbsmith?utm_source=edit-profile-page)
 
+## Run with Docker
+
+Build the image:
+
+```bash
+docker build -t micro-cap .
+```
+
+Execute the trading script:
+
+```bash
+docker run --rm -it micro-cap
+```
+
 Find a mistake in the logs or have advice?
 Please Reach out here: nathanbsmith.business@gmail.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+numpy
+matplotlib
+yfinance


### PR DESCRIPTION
## Summary
- Add Python 3.11 slim Dockerfile that installs requirements and runs trading script
- Document Docker build/run usage in README
- Add requirements.txt for pandas, numpy, matplotlib, yfinance

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c79c2938832485cda758060a8f11