### PR TITLE
FIX: Graph Date Range #65

### DIFF
--- a/Weekly Deep Research (MD)/Week 11 Summary.md
+++ b/Weekly Deep Research (MD)/Week 11 Summary.md
@@ -1,0 +1,15 @@
+# Thesis Review Summary
+
+In summary, our portfolio is positioning for strong catalyst-driven growth while tightening risk controls.
+We have exited Axogen to redeploy into more immediate opportunities, namely Fortress Biotech (upcoming
+FDA decision) and 4D Molecular Therapeutics (post-positive data momentum). Our core holdings Abeona
+and aTyr remain high-conviction to outperform the market – Abeona is transitioning to commercial stage
+with a funded runway , and aTyr is on the cusp of Phase 3 results that could be transformative.
+
+These two form the backbone of our thesis, supported by solid fundamentals and news flow. Fortress and
+4DMT add tactical spice: one a near-term binary event play, the other a beaten-down innovator with new
+validation. Overall, the portfolio is up ~32% in 9 weeks, far ahead of the S&P 500’s ~4.5% in the same
+period, and we aim to build on that lead . The coming week (Week 10) will be about catalyst anticipation
+and risk management – ensuring we have the right exposure levels as we head into late September’s event
+calendar. We will review the thesis on each name continuously and remain ready to adjust if the story
+changes


### PR DESCRIPTION
Computed graph_start and graph_end dynamically to enforce the proper date range before plotting

Start date is first data point, end point is  project end date or 6 month rolling window ( presently inside 6 months so shows end date, if a new project is started January then end date will be a 6 month rolling window to new ned date)