### PR TITLE
fix: replace bare except with except Exception in trading_script

### DIFF
--- a/Experiments/chatgpt_micro-cap/scripts/processing/trading_script.py
+++ b/Experiments/chatgpt_micro-cap/scripts/processing/trading_script.py
@@ -1262,7 +1262,7 @@ def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
                     elif dollar_volume < 100000:
                         print(f"  {ticker_str}: Low liquidity - ${dollar_volume:,.0f} traded today")
                         warnings_found = True
-        except:
+        except Exception:
             pass
     
     if not warnings_found:


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `trading_script.py` liquidity check. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.