### PR TITLE
Replace hand-rolled provider functions with LiteLLM

### DIFF
--- a/Experiments/multi_model_ipo/prompt_orchestration/prompt_models.py
+++ b/Experiments/multi_model_ipo/prompt_orchestration/prompt_models.py
@@ -1,130 +1,52 @@
-from openai import OpenAI
 import os
-import pandas as pd
-import anthropic
-from datetime import datetime
+
+import litellm
 from ..prompts.prompt_assembly import *
 from ..prompts.starting_prompt import create_starting_prompt
 
-def prompt_deepseek(text: str, model: str) -> str:
+# Bridge legacy env var so existing CLAUDE_API_KEY setups keep working
+if "ANTHROPIC_API_KEY" not in os.environ and "CLAUDE_API_KEY" in os.environ:
+    os.environ["ANTHROPIC_API_KEY"] = os.environ["CLAUDE_API_KEY"]
 
-    deepseek_client = OpenAI(
-    api_key=os.environ["DEEPSEEK_API_KEY"],
-    base_url="https://api.deepseek.com",)
-    
-    response = deepseek_client.chat.completions.create(
-        model=model,
+
+def _to_litellm_model(model: str) -> str:
+    if model.startswith("deepseek"):
+        return f"deepseek/{model}"
+    if model.startswith("grok"):
+        return f"xai/{model}"
+    return model
+
+
+def prompt_model(text: str, model: str) -> str:
+    response = litellm.completion(
+        model=_to_litellm_model(model),
         messages=[{"role": "user", "content": text}],
         temperature=0.0,
+        drop_params=True,
     )
 
     if not response.choices:
-        raise RuntimeError("No choices returned from DeepSeek.")
+        raise RuntimeError(f"No choices returned from {model}.")
 
     content = response.choices[0].message.content
     if content is None:
-        raise RuntimeError("Output from DeepSeek was None.")
+        raise RuntimeError(f"Output from {model} was None.")
 
     return content
 
-def prompt_chatgpt(text: str, model: str) -> str:
-    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": text}],
-        temperature=0.0,
-    )
-
-    if not response.choices:
-        raise RuntimeError("No choices returned from ChatGPT.")
-
-    content = response.choices[0].message.content
-    if content is None:
-        raise RuntimeError("Output from ChatGPT was None.")
-
-    return content
-
-def prompt_claude(text: str, model: str) -> str:
-
-    client = anthropic.Anthropic()
-    client.api_key = os.environ["CLAUDE_API_KEY"]
-
-    message = client.messages.create(
-    model=model,
-    max_tokens=10_000,
-    messages=[{
-        "role": "user",
-        "content": text
-    }]
-    )
-
-    content = message.content[0].text
-    if content is None:
-        raise RuntimeError("Output from Claude was None.")
-
-    return content
-
-def prompt_grok(text: str, model: str) -> str:
-
-    client = OpenAI(
-    api_key=os.environ["XAI_API_KEY"],
-    base_url="https://api.x.ai/v1",
-)
-    response = client.responses.create(
-        model=model,
-        input=[
-            {"role": "user", "content": text},
-        ],
-    )
-    if response is None:
-        raise RuntimeError("Response from Grok was None.")
-    if not response.output_text:
-        raise RuntimeError("Output text from Grok was None.")
-    return response.output_text
 
 def prompt_deep_research(skeleton, libb) -> tuple[str, str]:
-
     model = libb._model_path.replace("multi_model_ipo/artifacts/", "")
     text = create_deep_research_prompt(skeleton, libb)
-        
-    if "deepseek" in model:
-        return prompt_deepseek(text, model), text
-    elif "gpt" in model:
-        return prompt_chatgpt(text, model), text
-    elif "claude" in model:
-        return prompt_claude(text, model), text
-    elif "grok" in model:
-        return prompt_grok(text, model), text
-    else:
-        raise RuntimeError(f"Unidentified model: {model}")
+    return prompt_model(text, model), text
+
 
 def prompt_daily_report(skeleton, libb) -> tuple[str, str]:
-
     model = libb._model_path.replace("multi_model_ipo/artifacts/", "")
     text = create_daily_prompt(skeleton, libb)
-    if "deepseek" in model:
-        return prompt_deepseek(text, model), text
-    elif "gpt" in model:
-        return prompt_chatgpt(text, model), text
-    elif "claude" in model:
-        return prompt_claude(text, model), text
-    elif "grok" in model:
-        return prompt_grok(text, model), text
-    else:
-        raise RuntimeError(f"Unidentified model: {model}")
-    
-def prompt_starting_report(prompt: str, libb: LIBBmodel):
+    return prompt_model(text, model), text
 
+
+def prompt_starting_report(prompt: str, libb):
     model = libb._model_path.replace("multi_model_ipo/artifacts/", "")
-
-    if "deepseek" in model:
-        return prompt_deepseek(prompt, model)
-    elif "gpt" in model:
-        return prompt_chatgpt(prompt, model)
-    elif "claude" in model:
-        return prompt_claude(prompt, model)
-    elif "grok" in model:
-        return prompt_grok(prompt, model)
-
-    else:
-        raise RuntimeError(f"Unidentified model: {model}")
+    return prompt_model(prompt, model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ yfinance==0.2.65
 matplotlib==3.8.4
 pandas_market_calendars==5.3.2
 pysentiment2==0.1.1
-openai==2.32.0
+litellm==1.87.5
 python-dotenv==1.2.2
-anthropic==0.107.1
 git+https://github.com/LuckyOne7777/LLM-Investor-Behavior-Benchmark.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ yfinance==0.2.65
 matplotlib==3.8.4
 pandas_market_calendars==5.3.2
 pysentiment2==0.1.1
-litellm==1.87.5
+litellm>=1.80.0,<1.87.0
 python-dotenv==1.2.2
 git+https://github.com/LuckyOne7777/LLM-Investor-Behavior-Benchmark.git


### PR DESCRIPTION
### Motivation

`prompt_models.py` contains four separate provider functions (`prompt_chatgpt`, `prompt_claude`, `prompt_deepseek`, `prompt_grok`) plus three identical if/elif dispatcher chains that route by model name substring. Adding a new provider means writing a new function, updating all three dispatchers, and adding a new SDK dependency.

[LiteLLM](https://github.com/BerriAI/litellm) is an open-source AI gateway that provides a unified `completion()` interface for 100+ LLM providers using the OpenAI format. Replacing the hand-rolled functions with a single `litellm.completion()` call:

- Cuts `prompt_models.py` from 130 lines to 52
- Removes three copy-pasted if/elif dispatcher chains
- Makes adding a new provider zero-code (just add the model name to `MODELS` in `workflow.py`)
- Replaces direct `openai` + `anthropic` SDK dependencies with one dependency (`litellm`)


### Changes

| File | Change |
|---|---|
| `prompt_orchestration/prompt_models.py` | Replaced 4 provider functions + 3 dispatchers with single `prompt_model()` using `litellm.completion()` |
| `requirements.txt` | Removed `openai==2.32.0` and `anthropic==0.107.1`, added `litellm>=1.80.0,<1.87.0` (litellm installs both as transitive deps) |

### How provider routing works

LiteLLM routes based on model name prefixes (e.g., `anthropic/claude-sonnet-4-6`, `bedrock/anthropic.claude-3-sonnet`, `vertex_ai/gemini-2.0-flash`). A small `_to_litellm_model()` helper maps the repo's existing model names (`deepseek-*`, `grok-*`) to their LiteLLM prefix format so current configs keep working. Any of [LiteLLM's 100+ supported providers](https://docs.litellm.ai/docs/providers) can be used by passing the model name in LiteLLM format directly.

### Env var compatibility

LiteLLM reads the standard env vars automatically:

| Provider | Env var (same as before) |
|---|---|
| OpenAI | `OPENAI_API_KEY` |
| DeepSeek | `DEEPSEEK_API_KEY` |
| Anthropic | `ANTHROPIC_API_KEY` |
| xAI / Grok | `XAI_API_KEY` |

For backward compatibility, if `CLAUDE_API_KEY` is set but `ANTHROPIC_API_KEY` is not, the module bridges them automatically.

### Adding a new provider

Just add the model name in LiteLLM format to the `MODELS` list:
```python
MODELS = [..., "vertex_ai/gemini-2.0-flash", "bedrock/anthropic.claude-3-sonnet"]
```

No new functions, no new SDK dependencies, no dispatcher changes.

### Tested

```
$ python3 -c "
import litellm
response = litellm.completion(
    model='claude-sonnet-4-6',
    messages=[{'role': 'user', 'content': 'Say hello in exactly 5 words.'}],
    temperature=0.0, drop_params=True,
)
print(response.choices[0].message.content)
print(f'Model: {response.model}')
"
Hello there, how are you?
Model: claude-sonnet-4-6
```

Module import chain verified:
```
$ python3 -c "
from Experiments.multi_model_ipo.prompt_orchestration.prompt_models import (
    prompt_model, prompt_deep_research, prompt_daily_report, prompt_starting_report
)
print('All functions imported successfully')
"
All functions imported successfully
```
